### PR TITLE
Chrome Apps doc site has been changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ But they look and behave more like native apps, and they have super-powerful cap
 like the ability to interact with network and hardware devices, media tools, and much more.
 
 
-> This repository contains only the code for the Codelab. Please, make sense of this code by following the step-by-step tutorial in the [Chrome Apps docs site](http://developer.chrome.com/trunk/apps/app_codelab.html)
+> This repository contains only the code for the Codelab. Please, make sense of this code by following the step-by-step tutorial in the [Chrome Apps docs site](https://developer.chrome.com/apps/app_codelab_intro)


### PR DESCRIPTION
The chrome App doc site can be found https://developer.chrome.com/apps/about_apps